### PR TITLE
feat: Add 'Create Loan' button to navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,6 +80,9 @@ export default function Navbar() {
         </Link>
         {user ? (
           <>
+            <Link href="/create-loan" style={navStyles.navLink}>
+              Create Loan
+            </Link>
             <span style={navStyles.userInfo}>Hi, {user.email}</span>
             <button onClick={handleLogout} style={navStyles.logoutButton}>
               Logout


### PR DESCRIPTION
This commit adds a 'Create Loan' button to the navigation bar.

The button is implemented as a Next.js `Link` component that directs you to the `/create-loan` page. It is styled consistently with other navigation links.

The 'Create Loan' button is conditionally rendered and will only be visible to you if you are logged in. It is positioned next to the 'Dashboard' link in the navbar.